### PR TITLE
Maintenance and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,23 @@
 
 [Consul](https://www.consul.io) is an awesome service discovery and configuration provider.
 
+```clojure
+[consul-clojure "0.7.4"]
+```
+
 
 ## Changelog
+
+### 0.7.4
+
+Fixed `catalog-services` query to provide a hashmap wher the keys are the service name.
+Added test for the `catalog-services` operation.
+Fixed the prepared queries parameters handling.
+Updated dependencies.
+
+### 0.7.3
+
+Prepared queries support.
 
 ### 0.7.2
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ### 0.7.4
 
+> This is a **minor update** that **is BREAKING** for the `catalog-services` function.
+
 Fixed `catalog-services` query to return a hashmap with service names as keys. Previously the service names were kebab-cased and sometimes that would lead to service names that would not exist.
 Added test for the `catalog-services` operation.
 Fixed the prepared queries parameters handling.
@@ -28,7 +30,7 @@ Prepared queries support.
 [consul-clojure "0.7.1"]
 ```
 
-* [wkoelewijn] Fixes issue with TTL check
+* [jwkoelewijn] Fixes issue with TTL check
 
 ### 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### 0.7.4
 
-Fixed `catalog-services` query to return a hashmap with service names as keys .
+Fixed `catalog-services` query to return a hashmap with service names as keys. Previously the service names were kebab-cased and sometimes that would lead to service names that would not exist.
 Added test for the `catalog-services` operation.
 Fixed the prepared queries parameters handling.
 Updated dependencies.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### 0.7.4
 
-Fixed `catalog-services` query to provide a hashmap wher the keys are the service name.
+Fixed `catalog-services` query to return a hashmap with service names as keys .
 Added test for the `catalog-services` operation.
 Fixed the prepared queries parameters handling.
 Updated dependencies.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/consul-clojure "0.7.3"
+(defproject com.nedap.staffing-solutions/consul-clojure "0.7.4"
   :description "A Consul client for Clojure applications."
   :url "http://github.com/bpoweski/consul-clojure"
   :license {:name "Eclipse Public License"
@@ -9,8 +9,8 @@
                  "releases" {:url "https://nedap.jfrog.io/nedap/staffing-solutions/"
                              :username :env/artifactory_user
                              :password :env/artifactory_pass}}
-  :dependencies [[camel-snake-kebab "0.3.1" :exclusions [org.clojure/clojure com.keminglabs/cljx]]
-                 [cheshire "5.5.0"]
+  :dependencies [[camel-snake-kebab "0.4.1" :exclusions [org.clojure/clojure com.keminglabs/cljx]]
+                 [cheshire "5.10.0"]
                  [clj-http-lite "0.3.0" :exclusions [org.clojure/clojure]]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
-                                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
+                                  [org.clojure/core.async "1.1.587"]]}})

--- a/src/consul/core.clj
+++ b/src/consul/core.clj
@@ -654,6 +654,5 @@
    (explain-prepared-query conn query-id {}))
   ([conn query-id params]
    (-> (consul conn :get [:query (.toString query-id) :explain] {:query-params params})
-       :body
-       :Query)))
+       :body)))
 

--- a/src/consul/core.clj
+++ b/src/consul/core.clj
@@ -435,8 +435,7 @@
   ([conn]
    (catalog-datacenters conn {}))
   ([conn {:as params}]
-   (-> (consul-index conn :get [:catalog :datacenters] {:query-params params})
-       :body)))
+   (consul-index conn :get [:catalog :datacenters] {:query-params params})))
 
 (defn catalog-nodes
   ([conn]

--- a/src/consul/core.clj
+++ b/src/consul/core.clj
@@ -407,14 +407,12 @@
   ([conn service-id {:as params}]
    (consul-200 conn :put [:agent :service :deregister service-id] {:query-params params})))
 
-
 (defn agent-maintenance-service
   "Put a service into maintenance"
   ([conn service-id enable reason]
    (agent-maintenance-service conn service-id {:enable enable :reason reason}))
   ([conn service-id {:keys [enable reason] :as params}]
    (consul-200 conn :get [:agent :service :maintenance service-id] {:query-params params})))
-
 
 ;; Catalog endpoints - https://www.consul.io/docs/agent/http/catalog.html
 
@@ -437,7 +435,8 @@
   ([conn]
    (catalog-datacenters conn {}))
   ([conn {:as params}]
-   (consul-index conn :get [:catalog :datacenters] {:query-params params})))
+   (-> (consul-index conn :get [:catalog :datacenters] {:query-params params})
+       :body)))
 
 (defn catalog-nodes
   ([conn]
@@ -448,8 +447,8 @@
 (defn catalog-services
   ([conn]
    (catalog-services conn {}))
-  ([conn {:keys [dc] :as params}]
-   (:body (consul-index conn :get [:catalog :services] {:query-params params}))))
+  ([conn {:as params}]
+   (shallow-nameify-keys (:body (consul conn :get [:catalog :services] {:query-params params})))))
 
 (defn catalog-service
   ([conn service]
@@ -642,18 +641,19 @@
    (consul-200 conn :delete [:query (.toString query-id)] params)))
 
 (defn execute-prepared-query
-  "Execute a prepared query by either its ID (a UUID) or
-   its name"
+  "Execute a prepared query by either its ID (a UUID) or its name"
   ([conn query-id]
    (execute-prepared-query conn  query-id {}))
   ([conn query-id params]
-   (->> (consul conn :get [:query (.toString query-id) :execute] :query-params params)
-        :body
-        (cske/transform-keys csk/->kebab-case-keyword))))
+   (-> (consul-index conn :get [:query (.toString query-id) :execute] {:query-params params})
+       :body)))
 
 (defn explain-prepared-query
   "This generates a fully-rendered query for a given, post interpolation"
   ([conn query-id]
    (explain-prepared-query conn query-id {}))
   ([conn query-id params]
-   (:body (consul conn :get [:query (.toString query-id) :explain] :query-params params))))
+   (-> (consul conn :get [:query (.toString query-id) :explain] {:query-params params})
+       :body
+       :Query)))
+

--- a/test/consul/core_test.clj
+++ b/test/consul/core_test.clj
@@ -93,6 +93,18 @@
       (is (map? (get-in (agent-services :local) [service-id])))
       (is (= 2 (count (filter (comp #{service-id} :service-id) (vals (agent-checks :local)))))))))
 
+(deftest ^{:integration true} catalog-test
+  (testing "registering and deregistering a service using the agent but checking the catalog"
+    (let [service-id   (str "consul-clojure.service." (UUID/randomUUID))
+          service-name "service-test-name-api-v1-production"]
+      (is (nil?  (get (catalog-services :local) service-name)))
+      (is (true? (agent-register-service :local {:id   service-id
+                                                 :name service-name})))
+      (is (true? (contains? (catalog-services :local)
+                            service-name)))
+      (is (true? (agent-deregister-service :local service-id)))
+      (is (nil?  (get (catalog-services :local) service-name))))))
+
 (deftest ^{:integration true} prepared-query-test
   (testing "registering and removing prepared queries"
     (let [pq-name (str "consul-clojure.prepared-query." (UUID/randomUUID))]


### PR DESCRIPTION
Fixes the `catalog-services` query, the parameters handling of prepared query operations and updates dependencies.

The `catalog-services` query returned a hashmap with wrong keys (kebab-cased). The keys in the resulting hashmap are service names. Those service names would change with the kebab-case transformation, becoming names of services that doesn't exists.

I.E. `service_api_v1_production` -> `service-api-v-1-production`.

All changes are able to be streamed.